### PR TITLE
Convert FrameSummary objects to strings

### DIFF
--- a/priv/python3/erlport/erlang.py
+++ b/priv/python3/erlport/erlang.py
@@ -28,7 +28,7 @@
 from inspect import getargspec
 import sys
 from sys import exc_info
-from traceback import extract_tb
+from traceback import extract_tb, format_list
 from threading import Lock
 import uuid
 
@@ -234,7 +234,7 @@ class MessageHandler(object):
         except:
             t, val, tb = exc_info()
             exc = Atom(bytes("%s.%s" % (t.__module__, t.__name__), "utf-8"))
-            exc_tb = extract_tb(tb)
+            exc_tb = format_list(extract_tb(tb))
             exc_tb.reverse()
             error = Atom(b"python"), exc, str(val), exc_tb
             if mid is not None:


### PR DESCRIPTION
Since python 3.5, stack traces returned by python consist of a list of [FrameSummary](https://docs.python.org/3.5/library/traceback.html#framesummary-objects) objects. When a list of these objects is returned to erlang, erlport will automatically convert these into an opaque data type. This makes it troublesome to inspect stack traces from within Erlang / Elixir.

This pull request fixes this issue by automatically converting the list of frame summaries to a list of tuples.